### PR TITLE
api: Cygwin compatibility

### DIFF
--- a/wand/api.py
+++ b/wand/api.py
@@ -101,8 +101,9 @@ def library_paths():
                 libPath = winreg.QueryValueEx(reg_key, "LibPath")
                 coderPath = winreg.QueryValueEx(reg_key, "CoderModulesPath")
                 filterPath = winreg.QueryValueEx(reg_key, "FilterModulesPath")
-                os.environ['PATH'] += (libPath[0] + ";" +
-                                       coderPath[0] + ";" + filterPath[0] + ';')
+                pathSep = ';' if is_windows[1] == False else ':'
+                os.environ['PATH'] = (pathSep.join(libPath[0], coderPath[0], filterPath[0]) + 
+                                      os.environ['PATH'])
         except OSError:
             # otherwise do nothing; we assume the coder and
             # filter DLLs are in the same directory

--- a/wand/api.py
+++ b/wand/api.py
@@ -102,7 +102,7 @@ def library_paths():
                 coderPath = winreg.QueryValueEx(reg_key, "CoderModulesPath")
                 filterPath = winreg.QueryValueEx(reg_key, "FilterModulesPath")
                 pathSep = ';' if is_windows[1] == False else ':'
-                os.environ['PATH'] = (pathSep.join(libPath[0], coderPath[0], filterPath[0]) + 
+                os.environ['PATH'] = (pathSep.join((libPath[0], coderPath[0], filterPath[0])) + 
                                       os.environ['PATH'])
         except OSError:
             # otherwise do nothing; we assume the coder and


### PR DESCRIPTION
This change adds Cygwin compatibility by generalizing some Windows and Linux functionalities. In particular:

* Some tests for Windows are changed into one that consider and accept Cygwin/MSYS2 runtime layers.
* Registry values no longer change magick_home; they now influence PATH instead. ctypes on Windows search based on PATH.
* msvcrt-specific parts are not changed.
* *nix libc loading now default to the BSD "let ctypes find libc" loader, technically correct for every *nix system including Darwin. The hardcoded libc6 value is preserved as a fallback.
* *nix libmagick handling now accepts a separate library as found on Cygwin and MinGW.